### PR TITLE
Fix path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 SurfSync is a solution for managing multiple browsers and user profiles. This intuitive application makes it easy to switch between profiles, which is invaluable for people who need separate environments for different online activities. With SurfSync, syncing bookmarks, extensions and passwords becomes seamless, ensuring a unified browsing experience across all devices. Ideal for those who value organization, security and efficiency, SurfSync makes managing browsers simple and enjoyable.
 
+## Configuration
+
+The application reads executable paths from `SurfSync/Config/config.json`. Update this file with the paths to your browser executables so that each profile opens in the correct browser.
+
 # ToDo
 
 * add firefox browser

--- a/SurfSync/Config/ConfigReader.cs
+++ b/SurfSync/Config/ConfigReader.cs
@@ -29,7 +29,12 @@ public sealed class ConfigReader
             }
         }
 
-        //TODO: temporary hardcoded
-        return "C:\\Program Files\\Mozilla Firefox\\firefox.exe";
+        //TODO: temporary hardcoded defaults
+        return browserType switch
+        {
+            BrowserType.firefox => "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
+            BrowserType.chrome => "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            _ => string.Empty
+        };
     }
 }

--- a/SurfSync/Config/config.json
+++ b/SurfSync/Config/config.json
@@ -1,12 +1,12 @@
 ﻿{
 	"browsers": [
-		{
-			"type": "firefox",
-			"path": ""
-		},
-		{
-			"type": "chrome",
-			"path": ""
-		}
-	]
+                {
+                        "type": "firefox",
+                        "path": "C:/Program Files/Mozilla Firefox/firefox.exe"
+                },
+                {
+                        "type": "chrome",
+                        "path": "C:/Program Files/Google/Chrome/Application/chrome.exe"
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- fix default browser path resolution
- document configuration for setting browser paths
- update config.json with default example paths

## Testing
- `dotnet build SurfSync.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a6134c148328a2f324290da76f8d