### PR TITLE
Add placeholder browser services

### DIFF
--- a/SurfSync/Browsers/BraveService.cs
+++ b/SurfSync/Browsers/BraveService.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using SurfSync.Enums;
+using SurfSync.Models;
+using SurfSync.Config;
+
+namespace SurfSync.Browser;
+
+public sealed class BraveService : IBrowserService
+{
+    public BrowserType BrowserType => BrowserType.brave;
+    public MainWindow MainWindow { get; set; }
+
+    private readonly string _browserPath;
+
+    public BraveService()
+    {
+        _browserPath = ConfigReader.GetBrowserPath(BrowserType);
+    }
+
+    public List<Profile> GetProfiles() => new List<Profile>();
+
+    public void OpenBrowserProfileSettings()
+    {
+        // Not implemented yet
+    }
+
+    public void OpenBrowserWithProfile(Profile profile)
+    {
+        Process.Start(_browserPath);
+#if !DEBUG
+        MainWindow?.Close();
+#endif
+    }
+}

--- a/SurfSync/Browsers/EdgeService.cs
+++ b/SurfSync/Browsers/EdgeService.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using SurfSync.Enums;
+using SurfSync.Models;
+using SurfSync.Config;
+
+namespace SurfSync.Browser;
+
+public sealed class EdgeService : IBrowserService
+{
+    public BrowserType BrowserType => BrowserType.edge;
+    public MainWindow MainWindow { get; set; }
+
+    private readonly string _browserPath;
+
+    public EdgeService()
+    {
+        _browserPath = ConfigReader.GetBrowserPath(BrowserType);
+    }
+
+    public List<Profile> GetProfiles() => new List<Profile>();
+
+    public void OpenBrowserProfileSettings()
+    {
+        // Not implemented yet
+    }
+
+    public void OpenBrowserWithProfile(Profile profile)
+    {
+        Process.Start(_browserPath);
+#if !DEBUG
+        MainWindow?.Close();
+#endif
+    }
+}

--- a/SurfSync/Browsers/OperaService.cs
+++ b/SurfSync/Browsers/OperaService.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using SurfSync.Enums;
+using SurfSync.Models;
+using SurfSync.Config;
+
+namespace SurfSync.Browser;
+
+public sealed class OperaService : IBrowserService
+{
+    public BrowserType BrowserType => BrowserType.opera;
+    public MainWindow MainWindow { get; set; }
+
+    private readonly string _browserPath;
+
+    public OperaService()
+    {
+        _browserPath = ConfigReader.GetBrowserPath(BrowserType);
+    }
+
+    public List<Profile> GetProfiles() => new List<Profile>();
+
+    public void OpenBrowserProfileSettings()
+    {
+        // Not implemented yet
+    }
+
+    public void OpenBrowserWithProfile(Profile profile)
+    {
+        Process.Start(_browserPath);
+#if !DEBUG
+        MainWindow?.Close();
+#endif
+    }
+}

--- a/SurfSync/Config/ConfigReader.cs
+++ b/SurfSync/Config/ConfigReader.cs
@@ -34,6 +34,9 @@ public sealed class ConfigReader
         {
             BrowserType.firefox => "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
             BrowserType.chrome => "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            BrowserType.edge => "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+            BrowserType.opera => "C:\\Program Files\\Opera\\opera.exe",
+            BrowserType.brave => "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
             _ => string.Empty
         };
     }

--- a/SurfSync/Config/config.json
+++ b/SurfSync/Config/config.json
@@ -7,6 +7,18 @@
                 {
                         "type": "chrome",
                         "path": "C:/Program Files/Google/Chrome/Application/chrome.exe"
+                },
+                {
+                        "type": "edge",
+                        "path": "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe"
+                },
+                {
+                        "type": "opera",
+                        "path": "C:/Program Files/Opera/opera.exe"
+                },
+                {
+                        "type": "brave",
+                        "path": "C:/Program Files/BraveSoftware/Brave-Browser/Application/brave.exe"
                 }
         ]
 }

--- a/SurfSync/Enums/BrowserType.cs
+++ b/SurfSync/Enums/BrowserType.cs
@@ -3,5 +3,8 @@
 public enum BrowserType
 {
     firefox,
-    chrome
+    chrome,
+    edge,
+    opera,
+    brave
 }


### PR DESCRIPTION
## Summary
- add EdgeService, OperaService and BraveService
- extend `BrowserType` enum
- support new browsers in `ConfigReader`
- include sample paths in `config.json`

## Testing
- `dotnet build SurfSync/SurfSync.csproj -v q` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac93b59483289334041fc949fa1c